### PR TITLE
feat: admin 권한 세분화 및 기능별 접근 제어 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ com.pirogramming.recruit
 - **Database**: PostgreSQL with Spring Data JPA
 - **Authentication**: JWT with custom security configuration
 - **Documentation**: Swagger/OpenAPI 3
-- **Build Tool**: Gradle 8.5
+- **Build Tool**: Gradle 8.14.2
 - **Java Version**: 21
 - **Container**: Docker with multi-stage build
 
@@ -152,3 +152,8 @@ fix auth: resolve authentication error on login
 - Swagger UI available at `/swagger-ui.html`
 - Uses CommonMark for Markdown processing
 - Docker environment requires `.env` file with database credentials and API keys
+
+## Development Guidelines
+- ALWAYS prefer editing existing files over creating new ones
+- NEVER create files unless absolutely necessary for the task
+- NEVER proactively create documentation files (*.md) or README files unless explicitly requested

--- a/admin-api-spec.md
+++ b/admin-api-spec.md
@@ -1,0 +1,473 @@
+# Admin API 명세서
+
+## 개요
+관리자 인증, 권한 관리, 지원서 관리를 위한 Admin API 명세서입니다.
+
+## Base URL
+```
+http://localhost:8080/api/admin
+```
+
+## 인증 방식
+- JWT 기반 Bearer Token 인증
+- Access Token과 Refresh Token을 사용한 토큰 로테이션 방식
+
+---
+
+## 1. 인증 관리 API
+
+### 1.1 로그인
+관리자 로그인을 수행합니다.
+
+**Endpoint:** `POST /login`
+
+**Request Body:**
+```json
+{
+  "loginCode": "string"
+}
+```
+
+**Response:**
+```json
+{
+  "accessToken": "string",
+  "refreshToken": "string"
+}
+```
+
+**Status Codes:**
+- `200 OK`: 로그인 성공
+- `401 Unauthorized`: 잘못된 로그인 코드
+- `403 Forbidden`: 만료된 관리자 계정
+
+---
+
+### 1.2 토큰 갱신
+Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.
+
+**Endpoint:** `POST /refresh`
+
+**Request Body:**
+```json
+{
+  "refreshToken": "string"
+}
+```
+
+**Response:**
+```json
+{
+  "accessToken": "string",
+  "refreshToken": "string"
+}
+```
+
+**Status Codes:**
+- `200 OK`: 토큰 갱신 성공
+- `401 Unauthorized`: 유효하지 않은 Refresh Token
+
+---
+
+### 1.3 로그아웃
+Refresh Token을 무효화하여 로그아웃을 수행합니다.
+
+**Endpoint:** `POST /logout`
+
+**Request Body:**
+```json
+{
+  "refreshToken": "string"
+}
+```
+
+**Response:**
+- Status: `200 OK`
+- Body: 없음
+
+**Status Codes:**
+- `200 OK`: 로그아웃 성공
+- `401 Unauthorized`: 유효하지 않은 Refresh Token
+
+---
+
+### 1.4 API Key 토큰 교환
+외부 서비스에서 API Key를 JWT 토큰으로 교환합니다.
+
+**Endpoint:** `POST /token/exchange`
+
+**Request Body:**
+```json
+{
+  "apiKey": "string",
+  "purpose": "string"
+}
+```
+
+**Response:**
+```json
+{
+  "accessToken": "string",
+  "tokenType": "Bearer",
+  "expiresIn": 3600,
+  "purpose": "string"
+}
+```
+
+**Status Codes:**
+- `200 OK`: 토큰 교환 성공
+- `401 Unauthorized`: 유효하지 않은 API Key
+
+---
+
+## 2. General Admin 관리 API
+**권한 필요:** ROOT 권한
+
+### 2.1 General Admin 생성
+새로운 일반 관리자를 생성합니다.
+
+**Endpoint:** `POST /general`
+
+**Request Body:**
+```json
+{
+  "identifierName": "string",
+  "expiredAt": "2024-12-31T23:59:59"
+}
+```
+
+**Response:**
+```json
+{
+  "id": 1,
+  "loginCode": "ABC12345",
+  "identifierName": "평가자-001",
+  "role": "GENERAL",
+  "expiredAt": "2024-12-31T23:59:59",
+  "createdAt": "2024-01-01T00:00:00",
+  "updatedAt": "2024-01-01T00:00:00"
+}
+```
+
+**Status Codes:**
+- `200 OK`: 생성 성공
+- `403 Forbidden`: 권한 없음
+
+---
+
+### 2.2 General Admin 일괄 생성
+여러 일반 관리자를 일괄 생성합니다.
+
+**Endpoint:** `POST /general/batch`
+
+**Request Body:**
+```json
+{
+  "count": 5,
+  "expiredAt": "2024-12-31T23:59:59"
+}
+```
+
+**Response:**
+```json
+{
+  "count": 5,
+  "admins": [
+    {
+      "id": 1,
+      "loginCode": "ABC12345",
+      "identifierName": "평가자-001",
+      "role": "GENERAL",
+      "expiredAt": "2024-12-31T23:59:59",
+      "createdAt": "2024-01-01T00:00:00",
+      "updatedAt": "2024-01-01T00:00:00"
+    }
+  ]
+}
+```
+
+**Status Codes:**
+- `200 OK`: 생성 성공
+- `403 Forbidden`: 권한 없음
+
+---
+
+### 2.3 General Admin 목록 조회
+모든 일반 관리자 목록을 조회합니다.
+
+**Endpoint:** `GET /general`
+
+**Response:**
+```json
+[
+  {
+    "id": 1,
+    "loginCode": "ABC12345",
+    "identifierName": "평가자-001",
+    "role": "GENERAL",
+    "expiredAt": "2024-12-31T23:59:59",
+    "createdAt": "2024-01-01T00:00:00",
+    "updatedAt": "2024-01-01T00:00:00"
+  }
+]
+```
+
+**Status Codes:**
+- `200 OK`: 조회 성공
+- `403 Forbidden`: 권한 없음
+
+---
+
+### 2.4 만료된 General Admin 삭제
+만료된 일반 관리자를 삭제합니다.
+
+**Endpoint:** `DELETE /general/expired`
+
+**Response:**
+- Status: `200 OK`
+- Body: 없음
+
+**Status Codes:**
+- `200 OK`: 삭제 성공
+- `403 Forbidden`: 권한 없음
+
+---
+
+### 2.5 모든 General Admin 삭제
+모든 일반 관리자를 삭제합니다.
+
+**Endpoint:** `DELETE /general/all`
+
+**Response:**
+- Status: `200 OK`
+- Body: 없음
+
+**Status Codes:**
+- `200 OK`: 삭제 성공
+- `403 Forbidden`: 권한 없음
+
+---
+
+## 3. 지원서 관리 API
+**Base URL:** `/api/admin/applications`
+**권한 필요:** ROOT 또는 GENERAL 권한
+
+### 3.1 개별 합격 상태 변경
+특정 지원자의 합격 상태를 변경합니다.
+
+**Endpoint:** `PUT /applications/{id}/pass-status`
+
+**Path Parameters:**
+- `id`: 지원서 ID (Long)
+
+**Request Body:**
+```json
+{
+  "passStatus": "PASS" // PASS, FAIL, PENDING
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "googleFormId": 1,
+    "submissionId": "submission123",
+    "passStatus": "PASS",
+    "responses": {},
+    "createdAt": "2024-01-01T00:00:00",
+    "updatedAt": "2024-01-01T00:00:00"
+  },
+  "message": "합격 상태가 변경되었습니다.",
+  "status": 200
+}
+```
+
+---
+
+### 3.2 일괄 합격 상태 변경
+여러 지원자의 합격 상태를 일괄 변경합니다.
+
+**Endpoint:** `PUT /applications/all/pass-status`
+
+**Request Body:**
+```json
+{
+  "applicationIds": [1, 2, 3],
+  "passStatus": "PASS"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 1,
+      "googleFormId": 1,
+      "submissionId": "submission123",
+      "passStatus": "PASS",
+      "responses": {},
+      "createdAt": "2024-01-01T00:00:00",
+      "updatedAt": "2024-01-01T00:00:00"
+    }
+  ],
+  "message": "3명의 합격 상태가 변경되었습니다.",
+  "status": 200
+}
+```
+
+---
+
+### 3.3 합격 상태별 지원서 조회
+특정 합격 상태의 지원자들을 조회합니다.
+
+**Endpoint:** `GET /applications/pass-status/{status}`
+
+**Path Parameters:**
+- `status`: 합격 상태 (PASS, FAIL, PENDING)
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 1,
+      "googleFormId": 1,
+      "submissionId": "submission123",
+      "passStatus": "PASS",
+      "responses": {},
+      "createdAt": "2024-01-01T00:00:00",
+      "updatedAt": "2024-01-01T00:00:00"
+    }
+  ],
+  "message": "PASS 상태의 지원자 5명을 조회했습니다.",
+  "status": 200
+}
+```
+
+---
+
+### 3.4 합격 상태 통계 조회
+전체 지원자의 합격 상태 통계를 조회합니다.
+
+**Endpoint:** `GET /applications/pass-status/statistics`
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "PASS": 10,
+    "FAIL": 5,
+    "PENDING": 15
+  },
+  "message": "합격 상태 통계를 조회했습니다.",
+  "status": 200
+}
+```
+
+---
+
+### 3.5 구글 폼별 합격 상태 통계 조회
+특정 구글 폼의 합격 상태 통계를 조회합니다.
+
+**Endpoint:** `GET /applications/google-form/{googleFormId}/pass-status/statistics`
+
+**Path Parameters:**
+- `googleFormId`: 구글 폼 ID (Long)
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "PASS": 5,
+    "FAIL": 2,
+    "PENDING": 8
+  },
+  "message": "구글 폼 1의 합격 상태 통계를 조회했습니다.",
+  "status": 200
+}
+```
+
+---
+
+### 3.6 구글 폼별 + 합격 상태별 지원서 조회
+특정 구글 폼의 특정 합격 상태 지원자들을 조회합니다.
+
+**Endpoint:** `GET /applications/google-form/{googleFormId}/pass-status/{status}`
+
+**Path Parameters:**
+- `googleFormId`: 구글 폼 ID (Long)
+- `status`: 합격 상태 (PASS, FAIL, PENDING)
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 1,
+      "googleFormId": 1,
+      "submissionId": "submission123",
+      "passStatus": "PASS",
+      "responses": {},
+      "createdAt": "2024-01-01T00:00:00",
+      "updatedAt": "2024-01-01T00:00:00"
+    }
+  ],
+  "message": "구글 폼 1의 PASS 상태 지원자 3명을 조회했습니다.",
+  "status": 200
+}
+```
+
+---
+
+## 4. 에러 코드
+
+### 4.1 인증 관련 에러
+- `INVALID_LOGIN_CODE`: 잘못된 로그인 코드
+- `EXPIRED_ADMIN`: 만료된 관리자 계정
+- `INVALID_REFRESH_TOKEN`: 유효하지 않은 Refresh Token
+- `INVALID_API_KEY`: 유효하지 않은 API Key
+
+### 4.2 권한 관련 에러
+- `ADMIN_NOT_FOUND`: 관리자를 찾을 수 없음
+- `ACCESS_DENIED`: 접근 권한 없음
+
+---
+
+## 5. 권한 체계
+
+### 5.1 Admin Role
+- `ROOT`: 모든 기능 접근 가능
+- `GENERAL`: 지원서 관리 기능만 접근 가능
+- `WEBHOOK`: 웹훅 전용 (내부 시스템용)
+
+### 5.2 권한별 접근 가능 API
+- **ROOT**: 모든 API 접근 가능
+- **GENERAL**: 지원서 관리 API만 접근 가능
+- **WEBHOOK**: 웹훅 관련 API만 접근 가능
+
+---
+
+## 6. 보안 고려사항
+
+### 6.1 토큰 관리
+- Access Token 만료시간: 1시간
+- Refresh Token 만료시간: 7일
+- 토큰 로테이션 방식으로 보안성 강화
+
+### 6.2 General Admin 관리
+- 만료 날짜 설정으로 임시 계정 관리
+- 로그인 코드는 UUID 기반 8자리 자동 생성
+- 만료된 계정 자동 삭제 기능
+
+### 6.3 API Key 관리
+- 환경변수로 관리되는 웹훅 전용 API Key
+- 외부 서비스 인증용도로만 사용

--- a/src/main/java/com/pirogramming/recruit/domain/admin/controller/ApplicationManagementController.java
+++ b/src/main/java/com/pirogramming/recruit/domain/admin/controller/ApplicationManagementController.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 import com.pirogramming.recruit.domain.admin.dto.AllPassStatusUpdateRequest;
 import com.pirogramming.recruit.domain.admin.dto.PassStatusUpdateRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
+import com.pirogramming.recruit.global.security.RequireRoot;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Application Management", description = "지원서 관리 API (합격 처리)")
-@PreAuthorize("hasRole('ROOT') or hasRole('GENERAL')")
+@RequireRoot
 public class ApplicationManagementController {
 
     private final WebhookApplicationService webhookApplicationService;

--- a/src/main/java/com/pirogramming/recruit/domain/admin/controller/ApplicationManagementController.java
+++ b/src/main/java/com/pirogramming/recruit/domain/admin/controller/ApplicationManagementController.java
@@ -8,6 +8,7 @@ import com.pirogramming.recruit.domain.admin.dto.AllPassStatusUpdateRequest;
 import com.pirogramming.recruit.domain.admin.dto.PassStatusUpdateRequest;
 import org.springframework.http.ResponseEntity;
 import com.pirogramming.recruit.global.security.RequireRoot;
+import com.pirogramming.recruit.global.security.RequireAdmin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -32,13 +33,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Application Management", description = "지원서 관리 API (합격 처리)")
-@RequireRoot
 public class ApplicationManagementController {
 
     private final WebhookApplicationService webhookApplicationService;
 
     // 개별 합격 상태 변경
     @PutMapping("/{id}/pass-status")
+    @RequireRoot
     @Operation(summary = "합격 상태 변경", description = "지원자의 합격 상태를 변경합니다.")
     public ResponseEntity<ApiRes<WebhookApplicationResponse>> updatePassStatus(
             @Parameter(description = "지원서 ID") @PathVariable Long id,
@@ -56,6 +57,7 @@ public class ApplicationManagementController {
 
     // 일괄 합격 상태 변경
     @PutMapping("/all/pass-status")
+    @RequireRoot
     @Operation(summary = "일괄 합격 처리", description = "여러 지원자의 합격 상태를 일괄 변경합니다.")
     public ResponseEntity<ApiRes<List<WebhookApplicationResponse>>> updatePassStatusAll(
             @Valid @RequestBody AllPassStatusUpdateRequest request) {
@@ -78,6 +80,7 @@ public class ApplicationManagementController {
 
     // 합격 상태별 지원서 조회
     @GetMapping("/pass-status/{status}")
+    @RequireAdmin
     @Operation(summary = "합격 상태별 조회", description = "특정 합격 상태의 지원자들을 조회합니다.")
     public ResponseEntity<ApiRes<List<WebhookApplicationResponse>>> getApplicationsByPassStatus(
             @Parameter(description = "합격 상태") @PathVariable WebhookApplication.PassStatus status) {
@@ -95,6 +98,7 @@ public class ApplicationManagementController {
 
     // 합격 상태 통계 조회
     @GetMapping("/pass-status/statistics")
+    @RequireAdmin
     @Operation(summary = "합격 상태 통계", description = "전체 지원자의 합격 상태 통계를 조회합니다.")
     public ResponseEntity<ApiRes<Map<WebhookApplication.PassStatus, Long>>> getPassStatusStatistics() {
 
@@ -107,6 +111,7 @@ public class ApplicationManagementController {
 
     // 구글 폼별 합격 상태 통계 조회
     @GetMapping("/google-form/{googleFormId}/pass-status/statistics")
+    @RequireAdmin
     @Operation(summary = "구글 폼별 합격 상태 통계", description = "특정 구글 폼의 합격 상태 통계를 조회합니다.")
     public ResponseEntity<ApiRes<Map<WebhookApplication.PassStatus, Long>>> getPassStatusStatisticsByGoogleForm(
             @Parameter(description = "구글 폼 ID") @PathVariable Long googleFormId) {
@@ -122,6 +127,7 @@ public class ApplicationManagementController {
 
     // 구글 폼별 + 합격 상태별 지원서 조회
     @GetMapping("/google-form/{googleFormId}/pass-status/{status}")
+    @RequireAdmin
     @Operation(summary = "구글 폼별 합격 상태별 조회", description = "특정 구글 폼의 특정 합격 상태 지원자들을 조회합니다.")
     public ResponseEntity<ApiRes<List<WebhookApplicationResponse>>> getApplicationsByGoogleFormAndPassStatus(
             @Parameter(description = "구글 폼 ID") @PathVariable Long googleFormId,

--- a/src/main/java/com/pirogramming/recruit/domain/googleform/controller/GoogleFormController.java
+++ b/src/main/java/com/pirogramming/recruit/domain/googleform/controller/GoogleFormController.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import com.pirogramming.recruit.global.security.RequireRoot;
+import com.pirogramming.recruit.global.security.RequireAdmin;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +39,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "GoogleForm", description = "구글 폼 관리 API")
-@RequireRoot
 public class GoogleFormController {
 
     private final GoogleFormService googleFormService;
@@ -58,6 +58,7 @@ public class GoogleFormController {
 
     // 새 구글 폼 생성
     @PostMapping
+    @RequireRoot
     @Operation(summary = "새 구글 폼 생성", description = "새로운 구글 폼을 등록합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> createGoogleForm(
             @Valid @RequestBody GoogleFormRequest request) {
@@ -73,6 +74,7 @@ public class GoogleFormController {
 
     // 전체 구글 폼 목록 조회
     @GetMapping
+    @RequireAdmin
     @Operation(summary = "전체 구글 폼 조회", description = "모든 구글 폼을 최신순으로 조회합니다.")
     public ResponseEntity<ApiRes<List<GoogleFormResponse>>> getAllGoogleForms(
             @Parameter(description = "지원서 개수 포함 여부") @RequestParam(defaultValue = "true") boolean includeApplicationCount) {
@@ -103,6 +105,7 @@ public class GoogleFormController {
 
     // 특정 구글 폼 조회 (ID 기준)
     @GetMapping("/{id}")
+    @RequireAdmin
     @Operation(summary = "특정 구글 폼 조회", description = "ID를 기준으로 특정 구글 폼을 조회합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> getGoogleFormById(
             @Parameter(description = "구글 폼 ID") @PathVariable Long id,
@@ -121,6 +124,7 @@ public class GoogleFormController {
 
     // 폼 ID로 구글 폼 조회
     @GetMapping("/form-id/{formId}")
+    @RequireAdmin
     @Operation(summary = "폼 ID로 구글 폼 조회", description = "구글 폼 ID를 기준으로 구글 폼을 조회합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> getGoogleFormByFormId(
             @Parameter(description = "구글 폼 ID") @PathVariable String formId,
@@ -139,6 +143,7 @@ public class GoogleFormController {
 
     // 현재 활성화된 구글 폼 조회
     @GetMapping("/active")
+    @RequireAdmin
     @Operation(summary = "현재 활성화된 구글 폼 조회", description = "현재 활성화된 구글 폼을 조회합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> getActiveGoogleForm() {
 
@@ -154,6 +159,7 @@ public class GoogleFormController {
 
     // 구글 폼 활성화
     @PutMapping("/{id}/activate")
+    @RequireRoot
     @Operation(summary = "구글 폼 활성화", description = "특정 구글 폼을 활성화합니다. (기존 활성화된 것은 비활성화)")
     public ResponseEntity<ApiRes<GoogleFormResponse>> activateGoogleForm(
             @Parameter(description = "구글 폼 ID") @PathVariable Long id) {
@@ -170,6 +176,7 @@ public class GoogleFormController {
 
     // 구글 폼 비활성화
     @PutMapping("/{id}/deactivate")
+    @RequireRoot
     @Operation(summary = "구글 폼 비활성화", description = "특정 구글 폼을 비활성화합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> deactivateGoogleForm(
             @Parameter(description = "구글 폼 ID") @PathVariable Long id) {
@@ -186,6 +193,7 @@ public class GoogleFormController {
 
     // 구글 폼 URL 업데이트
     @PutMapping("/{id}/form-url")
+    @RequireRoot
     @Operation(summary = "구글 폼 URL 업데이트", description = "구글 폼의 URL을 업데이트합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> updateGoogleFormUrl(
             @Parameter(description = "구글 폼 ID") @PathVariable Long id,
@@ -209,6 +217,7 @@ public class GoogleFormController {
 
     // 구글 시트 URL 업데이트
     @PutMapping("/{id}/sheet-url")
+    @RequireRoot
     @Operation(summary = "구글 시트 URL 업데이트", description = "구글 시트의 URL을 업데이트합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> updateGoogleSheetUrl(
             @Parameter(description = "구글 폼 ID") @PathVariable Long id,
@@ -232,6 +241,7 @@ public class GoogleFormController {
 
     // 구글 폼 통계 정보 조회
     @GetMapping("/{id}/statistics")
+    @RequireAdmin
     @Operation(summary = "구글 폼 통계 정보", description = "특정 구글 폼의 상세 통계 정보를 조회합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> getGoogleFormStatistics(
             @Parameter(description = "구글 폼 ID") @PathVariable Long id) {
@@ -261,6 +271,7 @@ public class GoogleFormController {
 
     // 제목으로 구글 폼 검색
     @GetMapping("/search")
+    @RequireAdmin
     @Operation(summary = "제목으로 구글 폼 검색", description = "제목을 기준으로 구글 폼을 검색합니다.")
     public ResponseEntity<ApiRes<List<GoogleFormResponse>>> searchGoogleFormsByTitle(
             @Parameter(description = "검색할 제목") @RequestParam String title) {
@@ -277,6 +288,7 @@ public class GoogleFormController {
 
     // 구글 폼 삭제
     @DeleteMapping("/{id}")
+    @RequireRoot
     @Operation(summary = "구글 폼 삭제", description = "특정 구글 폼을 삭제합니다. 활성화된 폼은 삭제할 수 없습니다.")
     public ResponseEntity<ApiRes<Void>> deleteGoogleForm(
             @Parameter(description = "구글 폼 ID") @PathVariable Long id) {
@@ -292,6 +304,7 @@ public class GoogleFormController {
 
     // 특정 기수의 구글 폼들 조회
     @GetMapping("/generation/{generation}")
+    @RequireAdmin
     @Operation(summary = "특정 기수의 구글 폼들 조회", description = "특정 기수의 모든 구글 폼을 조회합니다.")
     public ResponseEntity<ApiRes<List<GoogleFormResponse>>> getGoogleFormsByGeneration(
             @Parameter(description = "기수") @PathVariable Integer generation,
@@ -322,6 +335,7 @@ public class GoogleFormController {
 
     // 특정 기수의 활성화된 구글 폼 조회
     @GetMapping("/generation/{generation}/active")
+    @RequireAdmin
     @Operation(summary = "특정 기수의 활성화된 구글 폼 조회", description = "특정 기수에서 현재 활성화된 구글 폼을 조회합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> getActiveGoogleFormByGeneration(
             @Parameter(description = "기수") @PathVariable Integer generation) {
@@ -337,6 +351,7 @@ public class GoogleFormController {
 
     // 현재 활성화된 기수 조회
     @GetMapping("/current-generation")
+    @RequireAdmin
     @Operation(summary = "현재 활성화된 기수 조회", description = "현재 활성화된 구글 폼의 기수를 조회합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> getCurrentGeneration() {
 
@@ -354,6 +369,7 @@ public class GoogleFormController {
 
     // 가장 최신 기수 조회
     @GetMapping("/latest-generation")
+    @RequireAdmin
     @Operation(summary = "가장 최신 기수 조회", description = "등록된 구글 폼 중 가장 최신 기수를 조회합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> getLatestGeneration() {
 
@@ -371,6 +387,7 @@ public class GoogleFormController {
 
     // 기수 업데이트
     @PutMapping("/{id}/generation")
+    @RequireRoot
     @Operation(summary = "구글 폼 기수 업데이트", description = "구글 폼의 기수를 업데이트합니다.")
     public ResponseEntity<ApiRes<GoogleFormResponse>> updateGoogleFormGeneration(
             @Parameter(description = "구글 폼 ID") @PathVariable Long id,
@@ -394,6 +411,7 @@ public class GoogleFormController {
 
     // 기수 범위로 구글 폼 조회
     @GetMapping("/generation-range")
+    @RequireAdmin
     @Operation(summary = "기수 범위로 구글 폼 조회", description = "특정 기수 범위의 구글 폼들을 조회합니다.")
     public ResponseEntity<ApiRes<List<GoogleFormResponse>>> getGoogleFormsByGenerationRange(
             @Parameter(description = "시작 기수") @RequestParam Integer startGeneration,

--- a/src/main/java/com/pirogramming/recruit/domain/googleform/controller/GoogleFormController.java
+++ b/src/main/java/com/pirogramming/recruit/domain/googleform/controller/GoogleFormController.java
@@ -28,6 +28,7 @@ import com.pirogramming.recruit.global.exception.code.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import com.pirogramming.recruit.global.security.RequireRoot;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "GoogleForm", description = "구글 폼 관리 API")
+@RequireRoot
 public class GoogleFormController {
 
     private final GoogleFormService googleFormService;

--- a/src/main/java/com/pirogramming/recruit/domain/googleform/entity/GoogleForm.java
+++ b/src/main/java/com/pirogramming/recruit/domain/googleform/entity/GoogleForm.java
@@ -1,6 +1,7 @@
 package com.pirogramming.recruit.domain.googleform.entity;
 
 import com.pirogramming.recruit.global.entity.BaseTimeEntity;
+import com.pirogramming.recruit.domain.webhook.entity.WebhookApplication;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "google_forms")
@@ -45,6 +48,10 @@ public class GoogleForm extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Integer generation; // 기수 (23, 24, 25기 등)
+
+    // 연관된 지원서들 (구글 폼 삭제 시 함께 삭제)
+    @OneToMany(mappedBy = "googleForm", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WebhookApplication> applications = new ArrayList<>();
 
     @Builder
     public GoogleForm(String formId, String title, String formUrl, String sheetUrl, String description, Integer generation, LocalDateTime recruitingStartDate, LocalDateTime recruitingEndDate) {

--- a/src/main/java/com/pirogramming/recruit/domain/integration/controller/IntegrationController.java
+++ b/src/main/java/com/pirogramming/recruit/domain/integration/controller/IntegrationController.java
@@ -2,7 +2,7 @@ package com.pirogramming.recruit.domain.integration.controller;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
+import com.pirogramming.recruit.global.security.RequireRoot;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Integration", description = "외부 시스템 연동 API (Apps Script, CSV 내보내기)")
-@PreAuthorize("hasRole('ROOT') or hasRole('GENERAL')")
+@RequireRoot
 public class IntegrationController {
 
     private final AppsScriptIntegrationService appsScriptIntegrationService;

--- a/src/main/java/com/pirogramming/recruit/domain/mail/controller/MailController.java
+++ b/src/main/java/com/pirogramming/recruit/domain/mail/controller/MailController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import com.pirogramming.recruit.global.security.RequireRoot;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/mail")
 @RequiredArgsConstructor
 @Tag(name = "Mail", description = "메일 발송 API")
+@RequireRoot
 public class MailController {
 
 	private final MailService mailService;

--- a/src/main/java/com/pirogramming/recruit/domain/mail/controller/MailSubscriberController.java
+++ b/src/main/java/com/pirogramming/recruit/domain/mail/controller/MailSubscriberController.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import com.pirogramming.recruit.global.security.RequireRoot;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -53,6 +54,7 @@ public class MailSubscriberController {
 		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@GetMapping("/{email}")
+	@RequireRoot
 	public ResponseEntity<ApiRes<MailSubscriberDto.Response>> getSubscriber(@PathVariable String email) {
 		MailSubscriberDto.Response response = mailSubscribeService.getSubscriber(email);
 		return ResponseEntity.ok(ApiRes.success(response));
@@ -64,6 +66,7 @@ public class MailSubscriberController {
 		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@GetMapping
+	@RequireRoot
 	public ResponseEntity<ApiRes<Page<MailSubscriberDto.Response>>> getAllSubscribers(
 			@PageableDefault(size = 20) Pageable pageable,
 			@RequestParam(required = false) String email) {
@@ -79,6 +82,7 @@ public class MailSubscriberController {
 		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@PutMapping("/{email}")
+	@RequireRoot
 	public ResponseEntity<ApiRes<MailSubscriberDto.Response>> updateSubscriber(
 			@PathVariable String email,
 			@Valid @RequestBody MailSubscriberDto.UpdateRequest request) {
@@ -93,6 +97,7 @@ public class MailSubscriberController {
 		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@DeleteMapping("/{email}")
+	@RequireRoot
 	public ResponseEntity<ApiRes<String>> deleteSubscriber(@PathVariable String email) {
 		mailSubscribeService.deleteSubscriber(email);
 		return ResponseEntity.ok(ApiRes.success("구독자가 성공적으로 삭제되었습니다"));
@@ -104,6 +109,7 @@ public class MailSubscriberController {
 		@ApiResponse(responseCode = "500", description = "서버 오류")
 	})
 	@GetMapping("/count")
+	@RequireRoot
 	public ResponseEntity<ApiRes<Long>> getSubscriberCount() {
 		long count = mailSubscribeService.getSubscriberCount();
 		return ResponseEntity.ok(ApiRes.success(count));

--- a/src/main/java/com/pirogramming/recruit/domain/webhook/controller/WebhookApplicationController.java
+++ b/src/main/java/com/pirogramming/recruit/domain/webhook/controller/WebhookApplicationController.java
@@ -23,6 +23,7 @@ import com.pirogramming.recruit.global.exception.code.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import com.pirogramming.recruit.global.security.RequireAdmin;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +54,7 @@ public class WebhookApplicationController {
 
     // 전체 지원서 목록 조회
     @GetMapping
+    @RequireAdmin
     @Operation(summary = "전체 지원서 조회", description = "저장된 모든 지원서를 최신순으로 조회합니다.")
     public ResponseEntity<ApiRes<List<WebhookApplicationResponse>>> getAllApplications() {
 
@@ -65,6 +67,7 @@ public class WebhookApplicationController {
 
     // 구글 폼별 지원서 목록 조회 (구글 폼 ID)
     @GetMapping("/google-form/{googleFormId}")
+    @RequireAdmin
     @Operation(summary = "구글 폼별 지원서 조회", description = "특정 구글 폼의 모든 지원서를 조회합니다.")
     public ResponseEntity<ApiRes<List<WebhookApplicationResponse>>> getApplicationsByGoogleForm(
             @Parameter(description = "구글 폼 ID") @PathVariable Long googleFormId) {
@@ -78,6 +81,7 @@ public class WebhookApplicationController {
 
     // 폼 ID별 지원서 목록 조회
     @GetMapping("/form-id/{formId}")
+    @RequireAdmin
     @Operation(summary = "폼 ID별 지원서 조회", description = "특정 폼 ID의 모든 지원서를 조회합니다.")
     public ResponseEntity<ApiRes<List<WebhookApplicationResponse>>> getApplicationsByFormId(
         @Parameter(description = "구글 폼 식별자") @PathVariable String formId) {
@@ -91,6 +95,7 @@ public class WebhookApplicationController {
 
     // 특정 지원서 조회 (ID 기준)
     @GetMapping("/{id}")
+    @RequireAdmin
     @Operation(summary = "특정 지원서 조회", description = "ID를 기준으로 특정 지원서를 조회합니다.")
     public ResponseEntity<ApiRes<WebhookApplicationResponse>> getApplicationById(
             @Parameter(description = "지원서 ID") @PathVariable Long id) {
@@ -103,6 +108,7 @@ public class WebhookApplicationController {
 
     // 이메일로 지원서 조회
     @GetMapping("/by-email")
+    @RequireAdmin
     @Operation(summary = "이메일로 지원서 조회", description = "이메일을 기준으로 지원서를 조회합니다.")
     public ResponseEntity<ApiRes<WebhookApplicationResponse>> getApplicationByEmail(
             @Parameter(description = "지원자 이메일") @RequestParam String email) {
@@ -115,6 +121,7 @@ public class WebhookApplicationController {
 
     // 구글 폼별 + 이메일로 지원서 조회
     @GetMapping("/google-form/{googleFormId}/by-email")
+    @RequireAdmin
     @Operation(summary = "구글 폼별 이메일로 지원서 조회", description = "특정 구글 폼에서 이메일을 기준으로 지원서를 조회합니다.")
     public ResponseEntity<ApiRes<WebhookApplicationResponse>> getApplicationByGoogleFormAndEmail(
             @Parameter(description = "구글 폼 ID") @PathVariable Long googleFormId,
@@ -128,6 +135,7 @@ public class WebhookApplicationController {
 
     // 폼 ID별 + 이메일로 지원서 조회
     @GetMapping("/form-id/{formId}/by-email")
+    @RequireAdmin
     @Operation(summary = "폼 ID별 이메일로 지원서 조회", description = "특정 폼 ID에서 이메일을 기준으로 지원서를 조회합니다.")
     public ResponseEntity<ApiRes<WebhookApplicationResponse>> getApplicationByFormIdAndEmail(
             @Parameter(description = "구글 폼 ID") @PathVariable String formId,
@@ -141,6 +149,7 @@ public class WebhookApplicationController {
 
     // 처리 상태별 지원서 조회
     @GetMapping("/by-status")
+    @RequireAdmin
     @Operation(summary = "상태별 지원서 조회", description = "처리 상태를 기준으로 지원서를 조회합니다.")
     public ResponseEntity<ApiRes<List<WebhookApplicationResponse>>> getApplicationsByStatus(
             @Parameter(description = "처리 상태 (PENDING, COMPLETED, FAILED)")
@@ -155,6 +164,7 @@ public class WebhookApplicationController {
 
     // 구글 폼별 + 상태별 지원서 조회
     @GetMapping("/google-form/{googleFormId}/by-status")
+    @RequireAdmin
     @Operation(summary = "구글 폼별 상태별 지원서 조회", description = "특정 구글 폼에서 처리 상태를 기준으로 지원서를 조회합니다.")
     public ResponseEntity<ApiRes<List<WebhookApplicationResponse>>> getApplicationsByGoogleFormAndStatus(
             @Parameter(description = "구글 폼 ID") @PathVariable Long googleFormId,
@@ -172,6 +182,7 @@ public class WebhookApplicationController {
 
     // 지원서 제출 여부 확인
     @GetMapping("/check")
+    @RequireAdmin
     @Operation(summary = "지원서 제출 여부 확인", description = "이메일을 기준으로 지원서 제출 여부를 확인합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> checkApplicationStatus(
             @Parameter(description = "확인할 이메일") @RequestParam String email) {
@@ -189,6 +200,7 @@ public class WebhookApplicationController {
 
     // 구글 폼별 지원서 제출 여부 확인
     @GetMapping("/google-form/{googleFormId}/check")
+    @RequireAdmin
     @Operation(summary = "구글 폼별 지원서 제출 여부 확인", description = "특정 구글 폼에서 이메일을 기준으로 지원서 제출 여부를 확인합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> checkApplicationStatusForGoogleForm(
             @Parameter(description = "구글 폼 ID") @PathVariable Long googleFormId,
@@ -208,6 +220,7 @@ public class WebhookApplicationController {
 
     // 폼 ID별 지원서 제출 여부 확인
     @GetMapping("/form-id/{formId}/check")
+    @RequireAdmin
     @Operation(summary = "폼 ID별 지원서 제출 여부 확인", description = "특정 폼 ID에서 이메일을 기준으로 지원서 제출 여부를 확인합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> checkApplicationStatusForFormId(
             @Parameter(description = "구글 폼 ID") @PathVariable String formId,
@@ -227,6 +240,7 @@ public class WebhookApplicationController {
 
     // 대기 중인 지원서 개수 조회
     @GetMapping("/pending-count")
+    @RequireAdmin
     @Operation(summary = "대기 중인 지원서 개수", description = "처리 대기 중인 지원서의 개수를 조회합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> getPendingApplicationCount() {
 
@@ -242,6 +256,7 @@ public class WebhookApplicationController {
 
     // 구글 폼별 지원서 개수 조회
     @GetMapping("/google-form/{googleFormId}/count")
+    @RequireAdmin
     @Operation(summary = "구글 폼별 지원서 개수", description = "특정 구글 폼의 총 지원서 개수를 조회합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> getApplicationCountByGoogleForm(
             @Parameter(description = "구글 폼 ID") @PathVariable Long googleFormId) {
@@ -259,6 +274,7 @@ public class WebhookApplicationController {
 
     // 폼 ID별 지원서 개수 조회
     @GetMapping("/form-id/{formId}/count")
+    @RequireAdmin
     @Operation(summary = "폼 ID별 지원서 개수", description = "특정 폼 ID의 총 지원서 개수를 조회합니다.")
     public ResponseEntity<ApiRes<Map<String, Object>>> getApplicationCountByFormId(
             @Parameter(description = "구글 폼 ID") @PathVariable String formId) {
@@ -276,6 +292,7 @@ public class WebhookApplicationController {
 
     // 상태별 통계 조회
     @GetMapping("/statistics")
+    @RequireAdmin
     @Operation(summary = "상태별 통계 조회", description = "전체 지원서의 상태별 통계를 조회합니다.")
     public ResponseEntity<ApiRes<Map<WebhookApplication.ProcessingStatus, Long>>> getStatusStatistics() {
 
@@ -286,6 +303,7 @@ public class WebhookApplicationController {
 
     // 구글 폼별 상태별 통계 조회
     @GetMapping("/google-form/{googleFormId}/statistics")
+    @RequireAdmin
     @Operation(summary = "구글 폼별 상태별 통계 조회", description = "특정 구글 폼의 상태별 통계를 조회합니다.")
     public ResponseEntity<ApiRes<Map<WebhookApplication.ProcessingStatus, Long>>> getStatusStatisticsByGoogleForm(
             @Parameter(description = "구글 폼 ID") @PathVariable Long googleFormId) {

--- a/src/main/java/com/pirogramming/recruit/global/config/SecurityConfig.java
+++ b/src/main/java/com/pirogramming/recruit/global/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
 				.requestMatchers("/api/admin/login", "/api/admin/refresh", "/api/admin/token/exchange").permitAll()
 				.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
 				.requestMatchers("/actuator/health").permitAll()
+				.requestMatchers("/mail/subscribers").permitAll()  // 이메일 구독은 인증 없이 접근 가능
 				.anyRequest().authenticated()
 			)
 			.exceptionHandling(except -> except

--- a/src/main/java/com/pirogramming/recruit/global/security/RequireAdmin.java
+++ b/src/main/java/com/pirogramming/recruit/global/security/RequireAdmin.java
@@ -1,0 +1,14 @@
+package com.pirogramming.recruit.global.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('ROOT') or hasRole('GENERAL')")
+public @interface RequireAdmin {
+}

--- a/src/main/java/com/pirogramming/recruit/global/security/RequireRoot.java
+++ b/src/main/java/com/pirogramming/recruit/global/security/RequireRoot.java
@@ -1,0 +1,14 @@
+package com.pirogramming.recruit.global.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('ROOT')")
+public @interface RequireRoot {
+}


### PR DESCRIPTION
## Summary
  - Admin 권한을 ROOT와 GENERAL로 세분화하여 기능별 접근 제어 구현
  - 이메일 구독 기능을 인증 없이 접근 가능하도록 설정
  - 구글 폼 삭제 시 연관된 지원서들도 함께 삭제되도록 cascade 설정 추가

  ## Changes
  ### 권한 분리 구현
  - `@RequireRoot`: ROOT 관리자만 접근 가능한 어노테이션 생성
  - `@RequireAdmin`: GENERAL + ROOT 관리자 접근 가능한 어노테이션 생성

  ### 접근 권한 설정
  **인증 없이 접근 가능:**
  - 이메일 구독 생성 (`POST /mail/subscribers`)

  **GENERAL + ROOT 관리자 접근 가능:**
  - 구글 폼 조회 관련 모든 엔드포인트
  - 지원서 조회 관련 모든 엔드포인트
  - 합격자 조회 및 통계

  **ROOT 관리자만 접근 가능:**
  - 리쿠르팅 생성/수정/삭제 (구글 폼 관리)
  - CSV 내보내기 (지원자, Admin 코드)
  - 이메일 전송 (단일/일괄)
  - 합격자 관리 (상태 변경)
  - 구독자 관리 (조회/수정/삭제)

  ### 데이터베이스 관계 개선
  - GoogleForm과 WebhookApplication 간 양방향 관계 설정
  - 구글 폼 삭제 시 연관된 지원서들 자동 삭제 (`cascade = CascadeType.ALL`)
