### PR TITLE
feat webhook: 지원서 상태 변경 API 구현 (단건/일괄)

### DIFF
--- a/src/main/java/com/pirogramming/recruit/domain/webhook/repository/WebhookApplicationRepository.java
+++ b/src/main/java/com/pirogramming/recruit/domain/webhook/repository/WebhookApplicationRepository.java
@@ -3,6 +3,7 @@ package com.pirogramming.recruit.domain.webhook.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -106,5 +107,9 @@ public interface WebhookApplicationRepository extends JpaRepository<WebhookAppli
 
     // 구글 폼별 + 합격 상태별 조회
     List<WebhookApplication> findByGoogleFormIdAndPassStatus(Long googleFormId, WebhookApplication.PassStatus passStatus);
+
+    // 평균 점수 상위 N명 조회 (평가가 있는 지원서만)
+    @Query("SELECT w FROM WebhookApplication w WHERE w.averageScore IS NOT NULL AND w.evaluationCount > 0 ORDER BY w.averageScore DESC")
+    List<WebhookApplication> findTopByAverageScore(Pageable pageable);
 
 }


### PR DESCRIPTION
## Summary
  - 단건 지원서 상태 변경 API 추가 (root 권한)
  - 일괄 지원서 상태 변경 API 추가 (점수 상위 N명, root 권한)
  - PassStatus 상태: PENDING(대기중), FIRST_PASS(1차 합격), FINAL_PASS(2차 합격), FAILED(불합격)