### PR TITLE
feat: 구글 폼별 지원서 일괄 상태 변경 API 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,12 @@ docker compose down -v
 
 # Run specific test class
 ./gradlew test --tests "com.pirogramming.recruit.domain.admin.AdminServiceTest"
+
+# Run tests with coverage
+./gradlew test jacocoTestReport
+
+# Continuous testing (watch mode)
+./gradlew -t test
 ```
 
 ## Project Architecture
@@ -73,12 +79,17 @@ com.pirogramming.recruit
 
 ### Key Technologies
 - **Framework**: Spring Boot 3.5.3 with Spring Security
-- **Database**: PostgreSQL with Spring Data JPA
-- **Authentication**: JWT with custom security configuration
-- **Documentation**: Swagger/OpenAPI 3
+- **Database**: PostgreSQL 15 with Spring Data JPA
+- **Authentication**: JWT with custom security configuration and refresh tokens
+- **Documentation**: Swagger/OpenAPI 3 (SpringDoc)
 - **Build Tool**: Gradle 8.14.2
 - **Java Version**: 21
 - **Container**: Docker with multi-stage build
+- **Email**: Spring Mail with Gmail SMTP
+- **File Processing**: Apache POI (Excel), Apache Commons CSV
+- **Markdown**: CommonMark with GFM tables extension
+- **AI Integration**: OpenAI API with WebClient
+- **JSON Processing**: Jackson with PostgreSQL JSONB support
 
 ### Database Configuration
 - Uses PostgreSQL 15 in Docker
@@ -162,12 +173,13 @@ fix auth: resolve authentication error on login
 ## Required Environment Variables
 The application requires the following environment variables in `.env` file:
 - `DB_USERNAME`, `DB_PASSWORD`: PostgreSQL database credentials
-- `JWT_SECRET`: JWT token signing secret
+- `JWT_SECRET`: JWT token signing secret (must be at least 256 bits for HS256)
 - `ROOT_ADMIN_LOGIN_CODE`: Root admin authentication code
 - `OPENAI_API_KEY`: OpenAI API key for AI summary features
 - `WEBHOOK_API_KEY`: API key for webhook authentication
 - `STMP_USER_ID`, `STMP_PASSWORD`: Gmail SMTP credentials for email service
 - `ADMIN_TEST_EMAIL`: Admin test email address (optional, defaults to rlarbdlf222@naver.com)
+- `SPRING_PROFILES_ACTIVE`: Environment profile (dev/prod, defaults to dev)
 
 ## Development Guidelines
 - ALWAYS prefer editing existing files over creating new ones

--- a/src/main/java/com/pirogramming/recruit/domain/webhook/dto/BatchPassStatusUpdateRequest.java
+++ b/src/main/java/com/pirogramming/recruit/domain/webhook/dto/BatchPassStatusUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.pirogramming.recruit.domain.webhook.dto;
+
+import java.util.List;
+
+import com.pirogramming.recruit.domain.webhook.entity.WebhookApplication;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "지원서 일괄 합격 상태 변경 요청")
+public class BatchPassStatusUpdateRequest {
+
+    @NotEmpty(message = "지원서 ID 목록은 필수입니다")
+    @Schema(description = "변경할 지원서 ID 목록", example = "[1, 2, 3, 4, 5]")
+    private List<Long> applicationIds;
+
+    @NotNull(message = "합격 상태는 필수입니다")
+    @Schema(description = "변경할 합격 상태", example = "FIRST_PASS")
+    private WebhookApplication.PassStatus passStatus;
+
+    public BatchPassStatusUpdateRequest(List<Long> applicationIds, WebhookApplication.PassStatus passStatus) {
+        this.applicationIds = applicationIds;
+        this.passStatus = passStatus;
+    }
+}

--- a/src/main/java/com/pirogramming/recruit/domain/webhook/dto/BatchPassStatusUpdateResponse.java
+++ b/src/main/java/com/pirogramming/recruit/domain/webhook/dto/BatchPassStatusUpdateResponse.java
@@ -1,0 +1,36 @@
+package com.pirogramming.recruit.domain.webhook.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "지원서 일괄 합격 상태 변경 응답")
+public class BatchPassStatusUpdateResponse {
+
+    @Schema(description = "업데이트된 지원서 목록")
+    private List<WebhookApplicationResponse> updatedApplications;
+
+    @Schema(description = "총 업데이트된 개수", example = "5")
+    private int totalUpdated;
+
+    @Schema(description = "업데이트 실패한 개수", example = "0")
+    private int failedCount;
+
+    @Schema(description = "변경된 합격 상태", example = "FIRST_PASS")
+    private String passStatus;
+
+    public BatchPassStatusUpdateResponse(List<WebhookApplicationResponse> updatedApplications, String passStatus) {
+        this.updatedApplications = updatedApplications;
+        this.totalUpdated = updatedApplications.size();
+        this.failedCount = 0; // 현재는 모두 성공하거나 예외 발생하는 구조
+        this.passStatus = passStatus;
+    }
+
+    public static BatchPassStatusUpdateResponse of(List<WebhookApplicationResponse> updatedApplications, String passStatus) {
+        return new BatchPassStatusUpdateResponse(updatedApplications, passStatus);
+    }
+}

--- a/src/main/java/com/pirogramming/recruit/domain/webhook/repository/WebhookApplicationRepository.java
+++ b/src/main/java/com/pirogramming/recruit/domain/webhook/repository/WebhookApplicationRepository.java
@@ -108,8 +108,13 @@ public interface WebhookApplicationRepository extends JpaRepository<WebhookAppli
     // 구글 폼별 + 합격 상태별 조회
     List<WebhookApplication> findByGoogleFormIdAndPassStatus(Long googleFormId, WebhookApplication.PassStatus passStatus);
 
-    // 평균 점수 상위 N명 조회 (평가가 있는 지원서만)
-    @Query("SELECT w FROM WebhookApplication w WHERE w.averageScore IS NOT NULL AND w.evaluationCount > 0 ORDER BY w.averageScore DESC")
-    List<WebhookApplication> findTopByAverageScore(Pageable pageable);
+
+    // 구글 폼별 평균 점수 상위 N명 조회 (평가가 있는 지원서만)
+    @Query("SELECT w FROM WebhookApplication w WHERE w.googleForm.id = :googleFormId AND w.averageScore IS NOT NULL AND w.evaluationCount > 0 ORDER BY w.averageScore DESC")
+    List<WebhookApplication> findTopByAverageScoreAndGoogleForm(@Param("googleFormId") Long googleFormId, Pageable pageable);
+
+    // 구글 폼별 평균 점수 하위 N명 조회 (평가가 있는 지원서만)
+    @Query("SELECT w FROM WebhookApplication w WHERE w.googleForm.id = :googleFormId AND w.averageScore IS NOT NULL AND w.evaluationCount > 0 ORDER BY w.averageScore ASC")
+    List<WebhookApplication> findBottomByAverageScoreAndGoogleForm(@Param("googleFormId") Long googleFormId, Pageable pageable);
 
 }


### PR DESCRIPTION
  Summary #76

  구글 폼별로 평가 점수 상위/하위 N명 지원서의 합격 상태를 일괄 변경할 수 있는 API를 추가했습니다.

  Changes

  새로 추가된 기능

  - 구글 폼별 상위 N명 상태 변경: POST /api/webhook/applications/google-form/{googleFormId}/bulk-status
  - 구글 폼별 하위 N명 상태 변경: POST /api/webhook/applications/google-form/{googleFormId}/bulk-status-bottom
  - 지정된 ID 목록 일괄 상태 변경: POST /api/webhook/applications/batch-status

  주요 구현 내용

  1. Repository Layer
    - findTopByAverageScoreAndGoogleForm(): 구글 폼별 상위 N명 조회
    - findBottomByAverageScoreAndGoogleForm(): 구글 폼별 하위 N명 조회
  2. Service Layer
    - updatePassStatusForTopNByGoogleForm(): 구글 폼별 상위 N명 상태 변경
    - updatePassStatusForBottomNByGoogleForm(): 구글 폼별 하위 N명 상태 변경
    - updatePassStatusAll(): ID 목록 기반 일괄 상태 변경
  3. Controller Layer
    - 구글 폼별 상위/하위 N명 엔드포인트 추가
    - ID 목록 기반 일괄 변경 엔드포인트 추가
    - Root 권한 필수 (@RequireRoot)
  4. DTO Classes
    - BatchPassStatusUpdateRequest: 일괄 상태 변경 요청 DTO
    - BatchPassStatusUpdateResponse: 일괄 상태 변경 응답 DTO

  정리된 내용

  - 전체 지원자 기준 일괄 변경 API 제거 (구글 폼별로 제한)
  - 불필요한 Repository 메서드 정리
  - 명확한 API 구조로 개선

  Technical Details

  - 선택 기준: 평가 점수가 있는 지원서만 대상 (averageScore IS NOT NULL AND evaluationCount > 0)
  - 상위 N명: 평균 점수 내림차순 정렬 후 N개 선택
  - 하위 N명: 평균 점수 오름차순 정렬 후 N개 선택
  - 트랜잭션 보장: 모든 변경이 성공하거나 전체 롤백
  - 권한 제어: Root 관리자만 사용 가능

  API Usage Examples

  # 25기 상위 20명 1차 합격 처리
  POST /api/webhook/applications/google-form/1/bulk-status?topN=20&passStatus=FIRST_PASS

  # 25기 하위 10명 불합격 처리
  POST /api/webhook/applications/google-form/1/bulk-status-bottom?bottomN=10&passStatus=FAILED

  # 지정된 ID들 일괄 상태 변경
  POST /api/webhook/applications/batch-status
  {
    "applicationIds": [1, 2, 3, 4, 5],
    "passStatus": "FIRST_PASS"
  }

